### PR TITLE
Format imports.

### DIFF
--- a/contracts/factory/examples/factory_schema.rs
+++ b/contracts/factory/examples/factory_schema.rs
@@ -1,12 +1,11 @@
 use std::env::current_dir;
 use std::fs::create_dir_all;
 
-use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
-
 use astroport::asset::PairInfo;
 use astroport::factory::{
     ConfigResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, PairsResponse, QueryMsg,
 };
+use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/contracts/factory/src/contract.rs
+++ b/contracts/factory/src/contract.rs
@@ -1,33 +1,30 @@
-use cosmwasm_std::{
-    attr, entry_point, from_binary, to_binary, Addr, Binary, CosmosMsg, Deps, DepsMut, Env,
-    MessageInfo, Order, Reply, ReplyOn, Response, StdError, StdResult, SubMsg, WasmMsg,
-};
-
-use crate::error::ContractError;
-use crate::migration;
-use crate::querier::query_pair_info;
-
-use crate::state::{
-    pair_key, read_pairs, Config, TmpPairInfo, CONFIG, OWNERSHIP_PROPOSAL, PAIRS, PAIRS_TO_MIGRATE,
-    PAIR_CONFIGS, TMP_PAIR_INFO,
-};
-
-use crate::response::MsgInstantiateContractResponse;
+use std::collections::HashSet;
 
 use astroport::asset::{addr_validate_to_lower, AssetInfo, PairInfo};
+use astroport::common::{claim_ownership, drop_ownership_proposal, propose_new_owner};
 use astroport::factory::{
     ConfigResponse, ExecuteMsg, FeeInfoResponse, InstantiateMsg, MigrateMsg, PairConfig, PairType,
     PairsResponse, QueryMsg,
 };
-
-use crate::migration::migrate_pair_configs_to_v120;
-use astroport::common::{claim_ownership, drop_ownership_proposal, propose_new_owner};
 use astroport::generator::ExecuteMsg::DeactivatePool;
 use astroport::pair::InstantiateMsg as PairInstantiateMsg;
+use cosmwasm_std::{
+    attr, entry_point, from_binary, to_binary, Addr, Binary, CosmosMsg, Deps, DepsMut, Env,
+    MessageInfo, Order, Reply, ReplyOn, Response, StdError, StdResult, SubMsg, WasmMsg,
+};
 use cw2::{get_contract_version, set_contract_version};
 use paloma_cosmwasm::PalomaQueryWrapper;
 use protobuf::Message;
-use std::collections::HashSet;
+
+use crate::error::ContractError;
+use crate::migration;
+use crate::migration::migrate_pair_configs_to_v120;
+use crate::querier::query_pair_info;
+use crate::response::MsgInstantiateContractResponse;
+use crate::state::{
+    pair_key, read_pairs, Config, TmpPairInfo, CONFIG, OWNERSHIP_PROPOSAL, PAIRS, PAIRS_TO_MIGRATE,
+    PAIR_CONFIGS, TMP_PAIR_INFO,
+};
 
 /// Contract name that is used for migration.
 const CONTRACT_NAME: &str = "astroport-factory";

--- a/contracts/factory/src/migration.rs
+++ b/contracts/factory/src/migration.rs
@@ -1,9 +1,10 @@
-use crate::state::PAIR_CONFIGS;
 use astroport::factory::{PairConfig, PairType};
 use cosmwasm_std::{Addr, StdError, Storage};
 use cw_storage_plus::{Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+use crate::state::PAIR_CONFIGS;
 
 /// This structure describes a contract migration message.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/factory/src/mock_querier.rs
+++ b/contracts/factory/src/mock_querier.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use astroport::asset::PairInfo;
 use astroport::pair::QueryMsg;
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
@@ -6,7 +8,6 @@ use cosmwasm_std::{
     QueryRequest, SystemError, SystemResult, WasmQuery,
 };
 use paloma_cosmwasm::PalomaQueryWrapper;
-use std::collections::HashMap;
 
 /// mock_dependencies is a drop-in replacement for cosmwasm_std::testing::mock_dependencies.
 /// This uses the Astroport CustomQuerier.

--- a/contracts/factory/src/state.rs
+++ b/contracts/factory/src/state.rs
@@ -1,14 +1,11 @@
-use cw_storage_plus::{Bound, Item, Map};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
-use cosmwasm_std::{Addr, Deps, Order};
-
 use astroport::asset::AssetInfo;
-
 use astroport::common::OwnershipProposal;
 use astroport::factory::PairConfig;
+use cosmwasm_std::{Addr, Deps, Order};
+use cw_storage_plus::{Bound, Item, Map};
 use paloma_cosmwasm::PalomaQueryWrapper;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 /// ## Description
 /// This structure holds the main contract parameters.

--- a/contracts/factory/src/testing.rs
+++ b/contracts/factory/src/testing.rs
@@ -1,25 +1,20 @@
-use cosmwasm_std::{
-    attr, from_binary, to_binary, Addr, Binary, Reply, ReplyOn, SubMsg, SubMsgResponse,
-    SubMsgResult, WasmMsg,
-};
-
-use crate::mock_querier::mock_dependencies;
-use crate::state::CONFIG;
-use crate::{
-    contract::{execute, instantiate, query},
-    error::ContractError,
-};
-
 use astroport::asset::{AssetInfo, PairInfo};
 use astroport::factory::{
     ConfigResponse, ExecuteMsg, InstantiateMsg, PairConfig, PairType, PairsResponse, QueryMsg,
 };
-
-use crate::contract::reply;
-use crate::response::MsgInstantiateContractResponse;
 use astroport::pair::InstantiateMsg as PairInstantiateMsg;
 use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
+use cosmwasm_std::{
+    attr, from_binary, to_binary, Addr, Binary, Reply, ReplyOn, SubMsg, SubMsgResponse,
+    SubMsgResult, WasmMsg,
+};
 use protobuf::Message;
+
+use crate::contract::{execute, instantiate, query, reply};
+use crate::error::ContractError;
+use crate::mock_querier::mock_dependencies;
+use crate::response::MsgInstantiateContractResponse;
+use crate::state::CONFIG;
 
 #[test]
 fn pair_type_to_string() {

--- a/contracts/oracle/examples/oracle_schema.rs
+++ b/contracts/oracle/examples/oracle_schema.rs
@@ -1,9 +1,8 @@
 use std::env::current_dir;
 use std::fs::create_dir_all;
 
-use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
-
 use astroport::oracle::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/contracts/oracle/src/contract.rs
+++ b/contracts/oracle/src/contract.rs
@@ -1,6 +1,3 @@
-use crate::error::ContractError;
-use crate::querier::{query_cumulative_prices, query_pair_info, query_prices};
-use crate::state::{Config, PriceCumulativeLast, CONFIG, PRICE_LAST};
 use astroport::asset::{addr_validate_to_lower, Asset, AssetInfo};
 use astroport::oracle::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use astroport::pair::TWAP_PRECISION;
@@ -11,6 +8,10 @@ use cosmwasm_std::{
 };
 use cw2::set_contract_version;
 use paloma_cosmwasm::PalomaQueryWrapper;
+
+use crate::error::ContractError;
+use crate::querier::{query_cumulative_prices, query_pair_info, query_prices};
+use crate::state::{Config, PriceCumulativeLast, CONFIG, PRICE_LAST};
 
 /// Contract name that is used for migration.
 const CONTRACT_NAME: &str = "astroport-oracle";

--- a/contracts/oracle/src/mock_querier.rs
+++ b/contracts/oracle/src/mock_querier.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use astroport::asset::{Asset, PairInfo};
 use astroport::factory::PairType;
 use astroport::factory::QueryMsg::Pair;
@@ -9,7 +11,6 @@ use cosmwasm_std::{
     QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
 };
 use paloma_cosmwasm::PalomaQueryWrapper;
-use std::collections::HashMap;
 
 pub fn mock_dependencies(
     contract_balance: &[Coin],

--- a/contracts/oracle/src/state.rs
+++ b/contracts/oracle/src/state.rs
@@ -1,9 +1,8 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
 use astroport::asset::{AssetInfo, PairInfo};
 use cosmwasm_std::{Addr, Decimal256, Uint128};
 use cw_storage_plus::Item;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 /// ## Description
 /// Stores the contract config at the given key

--- a/contracts/oracle/src/testing.rs
+++ b/contracts/oracle/src/testing.rs
@@ -1,9 +1,10 @@
-use crate::contract::{execute, instantiate};
-use crate::mock_querier::mock_dependencies;
 use astroport::asset::{Asset, AssetInfo};
 use astroport::oracle::{ExecuteMsg, InstantiateMsg};
 use cosmwasm_std::testing::{mock_env, mock_info};
 use cosmwasm_std::{Addr, Decimal256, Uint128, Uint256};
+
+use crate::contract::{execute, instantiate};
+use crate::mock_querier::mock_dependencies;
 
 #[test]
 fn decimal_overflow() {

--- a/contracts/pair/examples/pair_schema.rs
+++ b/contracts/pair/examples/pair_schema.rs
@@ -1,13 +1,12 @@
 use std::env::current_dir;
 use std::fs::create_dir_all;
 
-use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
-
 use astroport::asset::PairInfo;
 use astroport::pair::{
     CumulativePricesResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, PoolResponse,
     QueryMsg, ReverseSimulationResponse, SimulationResponse,
 };
+use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/contracts/pair/src/contract.rs
+++ b/contracts/pair/src/contract.rs
@@ -1,30 +1,30 @@
-use crate::error::ContractError;
-use crate::state::{Config, CONFIG};
+use std::str::FromStr;
+use std::vec;
 
+use astroport::asset::{addr_validate_to_lower, format_lp_token_name, Asset, AssetInfo, PairInfo};
+use astroport::factory::PairType;
+use astroport::generator::Cw20HookMsg as GeneratorHookMsg;
+use astroport::math::{to_decimal, to_decimal256};
+use astroport::pair::{
+    migration_check, ConfigResponse, CumulativePricesResponse, Cw20HookMsg, ExecuteMsg,
+    InstantiateMsg, MigrateMsg, PoolResponse, QueryMsg, ReverseSimulationResponse,
+    SimulationResponse, DEFAULT_SLIPPAGE, MAX_ALLOWED_SLIPPAGE, TWAP_PRECISION,
+};
+use astroport::querier::{query_factory_config, query_fee_info, query_supply};
+use astroport::token::InstantiateMsg as TokenInstantiateMsg;
 use cosmwasm_std::{
     attr, entry_point, from_binary, to_binary, Addr, Binary, CosmosMsg, Decimal, Decimal256, Deps,
     DepsMut, Env, Isqrt, MessageInfo, Reply, ReplyOn, Response, StdError, StdResult, SubMsg,
     Uint128, Uint256, WasmMsg,
 };
-
-use crate::response::MsgInstantiateContractResponse;
-use astroport::asset::{addr_validate_to_lower, format_lp_token_name, Asset, AssetInfo, PairInfo};
-use astroport::factory::PairType;
-use astroport::generator::Cw20HookMsg as GeneratorHookMsg;
-use astroport::math::{to_decimal, to_decimal256};
-use astroport::pair::{migration_check, ConfigResponse, DEFAULT_SLIPPAGE, MAX_ALLOWED_SLIPPAGE};
-use astroport::pair::{
-    CumulativePricesResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, PoolResponse,
-    QueryMsg, ReverseSimulationResponse, SimulationResponse, TWAP_PRECISION,
-};
-use astroport::querier::{query_factory_config, query_fee_info, query_supply};
-use astroport::token::InstantiateMsg as TokenInstantiateMsg;
 use cw2::set_contract_version;
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg, MinterResponse};
 use paloma_cosmwasm::PalomaQueryWrapper;
 use protobuf::Message;
-use std::str::FromStr;
-use std::vec;
+
+use crate::error::ContractError;
+use crate::response::MsgInstantiateContractResponse;
+use crate::state::{Config, CONFIG};
 
 /// Contract name that is used for migration.
 const CONTRACT_NAME: &str = "astroport-pair";

--- a/contracts/pair/src/mock_querier.rs
+++ b/contracts/pair/src/mock_querier.rs
@@ -1,12 +1,12 @@
+use std::collections::HashMap;
+
+use astroport::factory::FeeInfoResponse;
+use astroport::factory::QueryMsg::FeeInfo;
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
     from_binary, from_slice, to_binary, Addr, Coin, Decimal, OwnedDeps, Querier, QuerierResult,
     QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
 };
-use std::collections::HashMap;
-
-use astroport::factory::FeeInfoResponse;
-use astroport::factory::QueryMsg::FeeInfo;
 use cw20::{BalanceResponse, Cw20QueryMsg, TokenInfoResponse};
 use paloma_cosmwasm::{
     PalomaQuery, PalomaQueryWrapper, PalomaRoute, TaxCapResponse, TaxRateResponse,

--- a/contracts/pair/src/testing.rs
+++ b/contracts/pair/src/testing.rs
@@ -1,15 +1,5 @@
-use crate::contract::reply;
-use crate::contract::{
-    accumulate_prices, assert_max_spread, compute_swap, execute, instantiate, query_pair_info,
-    query_pool, query_reverse_simulation, query_share, query_simulation,
-};
-use crate::error::ContractError;
-use crate::mock_querier::mock_dependencies;
-use crate::response::MsgInstantiateContractResponse;
-use crate::state::Config;
 use astroport::asset::{Asset, AssetInfo, PairInfo};
 use astroport::factory::PairType;
-
 use astroport::pair::{
     Cw20HookMsg, ExecuteMsg, InstantiateMsg, PoolResponse, ReverseSimulationResponse,
     SimulationResponse, TWAP_PRECISION,
@@ -25,6 +15,15 @@ use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg, MinterResponse};
 use paloma_cosmwasm::PalomaQueryWrapper;
 use proptest::prelude::*;
 use protobuf::Message;
+
+use crate::contract::{
+    accumulate_prices, assert_max_spread, compute_swap, execute, instantiate, query_pair_info,
+    query_pool, query_reverse_simulation, query_share, query_simulation, reply,
+};
+use crate::error::ContractError;
+use crate::mock_querier::mock_dependencies;
+use crate::response::MsgInstantiateContractResponse;
+use crate::state::Config;
 
 fn store_liquidity_token(deps: DepsMut<PalomaQueryWrapper>, msg_id: u64, contract_addr: String) {
     let data = MsgInstantiateContractResponse {

--- a/contracts/pair_anchor/examples/pair_anchor_schema.rs
+++ b/contracts/pair_anchor/examples/pair_anchor_schema.rs
@@ -1,15 +1,13 @@
 use std::env::current_dir;
 use std::fs::create_dir_all;
 
-use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
-
 use astroport::asset::PairInfo;
+use astroport::pair::InstantiateMsg;
 use astroport::pair_anchor::{
     CumulativePricesResponse, Cw20HookMsg, ExecuteMsg, MigrateMsg, PoolResponse, QueryMsg,
     ReverseSimulationResponse, SimulationResponse,
 };
-
-use astroport::pair::InstantiateMsg;
+use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/contracts/pair_anchor/src/contract.rs
+++ b/contracts/pair_anchor/src/contract.rs
@@ -1,33 +1,30 @@
+use std::str::FromStr;
+use std::vec;
+
+use astroport::asset::{addr_validate_to_lower, Asset, AssetInfo, PairInfo};
+use astroport::factory::PairType;
+use astroport::math::{to_decimal, to_decimal256};
+use astroport::pair::{migration_check, InstantiateMsg};
+use astroport::pair_anchor::{
+    ConfigResponse, CumulativePricesResponse, Cw20HookMsg, ExecuteMsg, MigrateMsg, PoolResponse,
+    QueryMsg, ReverseSimulationResponse, SimulationResponse, DEFAULT_SLIPPAGE,
+    MAX_ALLOWED_SLIPPAGE,
+};
+use astroport::querier::query_fee_info;
+use cosmwasm_std::{
+    entry_point, from_binary, to_binary, Addr, Binary, Coin, CosmosMsg, Decimal, Decimal256, Deps,
+    DepsMut, Env, Fraction, MessageInfo, Response, StdError, StdResult, Uint128, Uint256, WasmMsg,
+};
+use cw2::set_contract_version;
+use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
+use paloma_cosmwasm::PalomaQueryWrapper;
+
 use crate::error::ContractError;
 use crate::market::{
     Cw20HookMsg as AnchorCw20HookMsg, EpochStateResponse, ExecuteMsg as AnchorExecuteMsg,
     QueryMsg as AnchorQueryMsg,
 };
 use crate::state::{Config, CONFIG};
-
-use astroport::querier::query_fee_info;
-
-use cosmwasm_std::{
-    entry_point, from_binary, to_binary, Addr, Binary, Coin, CosmosMsg, Decimal, Decimal256, Deps,
-    DepsMut, Env, Fraction, MessageInfo, Response, StdError, StdResult, Uint128, Uint256, WasmMsg,
-};
-
-use astroport::asset::{addr_validate_to_lower, Asset, AssetInfo, PairInfo};
-use astroport::factory::PairType;
-
-use astroport::pair::{migration_check, InstantiateMsg};
-use astroport::pair_anchor::{ConfigResponse, DEFAULT_SLIPPAGE, MAX_ALLOWED_SLIPPAGE};
-use astroport::pair_anchor::{
-    CumulativePricesResponse, Cw20HookMsg, ExecuteMsg, MigrateMsg, PoolResponse, QueryMsg,
-    ReverseSimulationResponse, SimulationResponse,
-};
-
-use astroport::math::{to_decimal, to_decimal256};
-use cw2::set_contract_version;
-use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
-use paloma_cosmwasm::PalomaQueryWrapper;
-use std::str::FromStr;
-use std::vec;
 
 /// Contract name that is used for migration.
 const CONTRACT_NAME: &str = "astroport-pair-anchor";

--- a/contracts/pair_anchor/src/market.rs
+++ b/contracts/pair_anchor/src/market.rs
@@ -1,8 +1,7 @@
 use cosmwasm_std::{Decimal256, Uint256};
+use cw20::Cw20ReceiveMsg;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-use cw20::Cw20ReceiveMsg;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/contracts/pair_anchor/src/mock_querier.rs
+++ b/contracts/pair_anchor/src/mock_querier.rs
@@ -1,19 +1,18 @@
-use crate::market::{EpochStateResponse, QueryMsg as AnchorQueryMsg};
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use astroport::factory::{FeeInfoResponse, QueryMsg};
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
     from_binary, from_slice, to_binary, Addr, Coin, Decimal, Decimal256, OwnedDeps, Querier,
     QuerierResult, QueryRequest, SystemError, SystemResult, Uint128, Uint256, WasmQuery,
 };
-use std::collections::HashMap;
-
-use astroport::factory::FeeInfoResponse;
-use astroport::factory::QueryMsg;
-
 use cw20::{BalanceResponse, Cw20QueryMsg, TokenInfoResponse};
 use paloma_cosmwasm::{
     PalomaQuery, PalomaQueryWrapper, PalomaRoute, TaxCapResponse, TaxRateResponse,
 };
-use std::str::FromStr;
+
+use crate::market::{EpochStateResponse, QueryMsg as AnchorQueryMsg};
 
 /// mock_dependencies is a drop-in replacement for cosmwasm_std::testing::mock_dependencies.
 /// This uses the Astroport CustomQuerier.

--- a/contracts/pair_anchor/src/testing.rs
+++ b/contracts/pair_anchor/src/testing.rs
@@ -1,10 +1,3 @@
-use crate::contract::{
-    assert_max_spread, execute, instantiate, query_pair_info, query_pool, query_reverse_simulation,
-    query_share, query_simulation,
-};
-use crate::error::ContractError;
-use crate::market::{Cw20HookMsg as AnchorCw20HookMsg, ExecuteMsg as AnchorExecuteMsg};
-use crate::mock_querier::mock_dependencies;
 use astroport::asset::{Asset, AssetInfo, PairInfo};
 use astroport::pair::InstantiateMsg;
 use astroport::pair_anchor::{
@@ -16,6 +9,14 @@ use cosmwasm_std::{
     ReplyOn, SubMsg, Timestamp, Uint128, WasmMsg,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
+
+use crate::contract::{
+    assert_max_spread, execute, instantiate, query_pair_info, query_pool, query_reverse_simulation,
+    query_share, query_simulation,
+};
+use crate::error::ContractError;
+use crate::market::{Cw20HookMsg as AnchorCw20HookMsg, ExecuteMsg as AnchorExecuteMsg};
+use crate::mock_querier::mock_dependencies;
 
 const MOCK_ANCHOR_ADDR: &str = "anchor";
 const MOCK_ANCHOR_TOKEN: &str = "addr1aust";

--- a/contracts/pair_stable/examples/pair_stable_schema.rs
+++ b/contracts/pair_stable/examples/pair_stable_schema.rs
@@ -1,13 +1,12 @@
 use std::env::current_dir;
 use std::fs::create_dir_all;
 
-use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
-
 use astroport::asset::PairInfo;
 use astroport::pair::{
     CumulativePricesResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, PoolResponse,
     QueryMsg, ReverseSimulationResponse, SimulationResponse,
 };
+use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/contracts/pair_stable/src/contract.rs
+++ b/contracts/pair_stable/src/contract.rs
@@ -1,42 +1,38 @@
-use crate::error::ContractError;
-use crate::math::{
-    calc_ask_amount, calc_offer_amount, compute_d, AMP_PRECISION, MAX_AMP, MAX_AMP_CHANGE,
-    MIN_AMP_CHANGING_TIME, N_COINS,
-};
-use crate::state::{Config, CONFIG};
+use std::cmp::Ordering;
+use std::str::FromStr;
+use std::vec;
 
-use cosmwasm_std::{
-    attr, entry_point, from_binary, to_binary, Addr, Binary, CosmosMsg, Decimal, Decimal256, Deps,
-    DepsMut, Env, Isqrt, MessageInfo, Reply, ReplyOn, Response, StdError, StdResult, SubMsg,
-    Uint128, Uint256, Uint64, WasmMsg,
-};
-
-use crate::response::MsgInstantiateContractResponse;
 use astroport::asset::{addr_validate_to_lower, format_lp_token_name, Asset, AssetInfo, PairInfo};
 use astroport::factory::PairType;
-
 use astroport::generator::Cw20HookMsg as GeneratorHookMsg;
-use astroport::pair::{
-    migration_check, ConfigResponse, InstantiateMsg, StablePoolParams, StablePoolUpdateParams,
-    DEFAULT_SLIPPAGE, MAX_ALLOWED_SLIPPAGE, TWAP_PRECISION,
-};
-
 use astroport::math::{to_decimal, to_decimal256};
 use astroport::pair::{
-    CumulativePricesResponse, Cw20HookMsg, ExecuteMsg, MigrateMsg, PoolResponse, QueryMsg,
-    ReverseSimulationResponse, SimulationResponse, StablePoolConfig,
+    migration_check, ConfigResponse, CumulativePricesResponse, Cw20HookMsg, ExecuteMsg,
+    InstantiateMsg, MigrateMsg, PoolResponse, QueryMsg, ReverseSimulationResponse,
+    SimulationResponse, StablePoolConfig, StablePoolParams, StablePoolUpdateParams,
+    DEFAULT_SLIPPAGE, MAX_ALLOWED_SLIPPAGE, TWAP_PRECISION,
 };
 use astroport::querier::{
     query_factory_config, query_fee_info, query_supply, query_token_precision,
 };
 use astroport::token;
+use cosmwasm_std::{
+    attr, entry_point, from_binary, to_binary, Addr, Binary, CosmosMsg, Decimal, Decimal256, Deps,
+    DepsMut, Env, Isqrt, MessageInfo, Reply, ReplyOn, Response, StdError, StdResult, SubMsg,
+    Uint128, Uint256, Uint64, WasmMsg,
+};
 use cw2::set_contract_version;
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg, MinterResponse};
 use paloma_cosmwasm::PalomaQueryWrapper;
 use protobuf::Message;
-use std::cmp::Ordering;
-use std::str::FromStr;
-use std::vec;
+
+use crate::error::ContractError;
+use crate::math::{
+    calc_ask_amount, calc_offer_amount, compute_d, AMP_PRECISION, MAX_AMP, MAX_AMP_CHANGE,
+    MIN_AMP_CHANGING_TIME, N_COINS,
+};
+use crate::response::MsgInstantiateContractResponse;
+use crate::state::{Config, CONFIG};
 
 /// Contract name that is used for migration.
 const CONTRACT_NAME: &str = "astroport-pair-stable";

--- a/contracts/pair_stable/src/error.rs
+++ b/contracts/pair_stable/src/error.rs
@@ -1,6 +1,7 @@
-use crate::math::{MAX_AMP, MAX_AMP_CHANGE, MIN_AMP_CHANGING_TIME};
 use cosmwasm_std::{OverflowError, StdError};
 use thiserror::Error;
+
+use crate::math::{MAX_AMP, MAX_AMP_CHANGE, MIN_AMP_CHANGING_TIME};
 
 /// ## Description
 /// This enum describes stableswap pair contract errors!

--- a/contracts/pair_stable/src/math.rs
+++ b/contracts/pair_stable/src/math.rs
@@ -1,5 +1,6 @@
-use cosmwasm_std::{Uint128, Uint256};
 use std::convert::TryFrom;
+
+use cosmwasm_std::{Uint128, Uint256};
 
 const N_COINS_SQUARED: u8 = 4;
 const ITERATIONS: u8 = 32;

--- a/contracts/pair_stable/src/mock_querier.rs
+++ b/contracts/pair_stable/src/mock_querier.rs
@@ -1,12 +1,12 @@
+use std::collections::HashMap;
+
+use astroport::factory::FeeInfoResponse;
+use astroport::factory::QueryMsg::FeeInfo;
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
     from_binary, from_slice, to_binary, Addr, Coin, Decimal, OwnedDeps, Querier, QuerierResult,
     QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
 };
-use std::collections::HashMap;
-
-use astroport::factory::FeeInfoResponse;
-use astroport::factory::QueryMsg::FeeInfo;
 use cw20::{BalanceResponse, Cw20QueryMsg, TokenInfoResponse};
 use paloma_cosmwasm::{
     PalomaQuery, PalomaQueryWrapper, PalomaRoute, TaxCapResponse, TaxRateResponse,

--- a/contracts/pair_stable/src/testing.rs
+++ b/contracts/pair_stable/src/testing.rs
@@ -1,15 +1,4 @@
-use crate::contract::{
-    accumulate_prices, assert_max_spread, execute, instantiate, query_pair_info, query_pool,
-    query_share, query_simulation, reply,
-};
-use crate::error::ContractError;
-use crate::math::{calc_ask_amount, calc_offer_amount, AMP_PRECISION};
-use crate::mock_querier::mock_dependencies;
-
-use crate::response::MsgInstantiateContractResponse;
-use crate::state::Config;
 use astroport::asset::{Asset, AssetInfo, PairInfo};
-
 use astroport::pair::{
     Cw20HookMsg, ExecuteMsg, InstantiateMsg, PoolResponse, SimulationResponse, StablePoolParams,
     TWAP_PRECISION,
@@ -23,6 +12,16 @@ use cosmwasm_std::{
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg, MinterResponse};
 use protobuf::Message;
+
+use crate::contract::{
+    accumulate_prices, assert_max_spread, execute, instantiate, query_pair_info, query_pool,
+    query_share, query_simulation, reply,
+};
+use crate::error::ContractError;
+use crate::math::{calc_ask_amount, calc_offer_amount, AMP_PRECISION};
+use crate::mock_querier::mock_dependencies;
+use crate::response::MsgInstantiateContractResponse;
+use crate::state::Config;
 
 fn store_liquidity_token(deps: DepsMut<PalomaQueryWrapper>, msg_id: u64, contract_addr: String) {
     let data = MsgInstantiateContractResponse {

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -1,12 +1,4 @@
-use cosmwasm_std::{
-    entry_point, from_binary, to_binary, Addr, Api, Binary, Coin, CosmosMsg, Decimal, Deps,
-    DepsMut, Env, MessageInfo, QueryRequest, Response, StdError, StdResult, Uint128, WasmMsg,
-    WasmQuery,
-};
-
-use crate::error::ContractError;
-use crate::operations::execute_swap_operation;
-use crate::state::{Config, CONFIG};
+use std::collections::HashMap;
 
 use astroport::asset::{addr_validate_to_lower, Asset, AssetInfo, PairInfo};
 use astroport::pair::{QueryMsg as PairQueryMsg, SimulationResponse};
@@ -15,10 +7,18 @@ use astroport::router::{
     ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
     SimulateSwapOperationsResponse, SwapOperation, MAX_SWAP_OPERATIONS,
 };
+use cosmwasm_std::{
+    entry_point, from_binary, to_binary, Addr, Api, Binary, Coin, CosmosMsg, Decimal, Deps,
+    DepsMut, Env, MessageInfo, QueryRequest, Response, StdError, StdResult, Uint128, WasmMsg,
+    WasmQuery,
+};
 use cw2::set_contract_version;
 use cw20::Cw20ReceiveMsg;
 use paloma_cosmwasm::{PalomaMsgWrapper, PalomaQuerier, PalomaQueryWrapper, SwapResponse};
-use std::collections::HashMap;
+
+use crate::error::ContractError;
+use crate::operations::execute_swap_operation;
+use crate::state::{Config, CONFIG};
 
 /// Contract name that is used for migration.
 const CONTRACT_NAME: &str = "astroport-router";

--- a/contracts/router/src/operations.rs
+++ b/contracts/router/src/operations.rs
@@ -1,18 +1,17 @@
-use cosmwasm_std::{
-    to_binary, Coin, CosmosMsg, Decimal, DepsMut, Env, MessageInfo, Response, StdResult, WasmMsg,
-};
-
-use crate::error::ContractError;
-use crate::state::{Config, CONFIG};
-
 use astroport::asset::{Asset, AssetInfo, PairInfo};
 use astroport::pair::ExecuteMsg as PairExecuteMsg;
 use astroport::querier::{query_balance, query_pair_info, query_token_balance};
 use astroport::router::SwapOperation;
+use cosmwasm_std::{
+    to_binary, Coin, CosmosMsg, Decimal, DepsMut, Env, MessageInfo, Response, StdResult, WasmMsg,
+};
 use cw20::Cw20ExecuteMsg;
 use paloma_cosmwasm::{
     create_swap_msg, create_swap_send_msg, PalomaMsgWrapper, PalomaQueryWrapper,
 };
+
+use crate::error::ContractError;
+use crate::state::{Config, CONFIG};
 
 /// ## Description
 /// Execute a swap operation. Returns a [`ContractError`] on failure, otherwise returns a [`Response`] with the

--- a/contracts/router/src/state.rs
+++ b/contracts/router/src/state.rs
@@ -1,8 +1,7 @@
+use cosmwasm_std::Addr;
 use cw_storage_plus::Item;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-use cosmwasm_std::Addr;
 
 /// ## Description
 /// Stores the contract config at the given key

--- a/contracts/router/src/testing/mock_querier.rs
+++ b/contracts/router/src/testing/mock_querier.rs
@@ -1,19 +1,19 @@
-use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
-use cosmwasm_std::{
-    from_binary, from_slice, to_binary, Addr, Binary, Coin, ContractResult, Decimal, OwnedDeps,
-    Querier, QuerierResult, QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
-};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use astroport::asset::{Asset, AssetInfo, PairInfo};
 use astroport::factory::PairType;
 use astroport::pair::SimulationResponse;
+use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
+use cosmwasm_std::{
+    from_binary, from_slice, to_binary, Addr, Binary, Coin, ContractResult, Decimal, OwnedDeps,
+    Querier, QuerierResult, QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
+};
 use cw20::{BalanceResponse, Cw20QueryMsg, TokenInfoResponse};
 use paloma_cosmwasm::{
     PalomaQuery, PalomaQueryWrapper, PalomaRoute, SwapResponse, TaxCapResponse, TaxRateResponse,
 };
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/contracts/router/src/testing/tests.rs
+++ b/contracts/router/src/testing/tests.rs
@@ -1,21 +1,19 @@
-use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
-use cosmwasm_std::{
-    from_binary, to_binary, Addr, Coin, Decimal, ReplyOn, SubMsg, Uint128, WasmMsg,
-};
-
-use crate::contract::{execute, instantiate, query};
-use crate::error::ContractError;
-use crate::testing::mock_querier::mock_dependencies;
-
-use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
-
 use astroport::asset::{Asset, AssetInfo};
 use astroport::pair::ExecuteMsg as PairExecuteMsg;
 use astroport::router::{
     ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg,
     SimulateSwapOperationsResponse, SwapOperation, MAX_SWAP_OPERATIONS,
 };
+use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
+use cosmwasm_std::{
+    from_binary, to_binary, Addr, Coin, Decimal, ReplyOn, SubMsg, Uint128, WasmMsg,
+};
+use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use paloma_cosmwasm::{create_swap_msg, create_swap_send_msg};
+
+use crate::contract::{execute, instantiate, query};
+use crate::error::ContractError;
+use crate::testing::mock_querier::mock_dependencies;
 
 #[test]
 fn proper_initialization() {

--- a/contracts/token/examples/token_schema.rs
+++ b/contracts/token/examples/token_schema.rs
@@ -1,9 +1,8 @@
 use std::env::current_dir;
 use std::fs::create_dir_all;
 
-use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
-
 use astroport::token::InstantiateMsg;
+use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
 use cw20::{
     AllAccountsResponse, AllAllowancesResponse, AllowanceResponse, BalanceResponse, MinterResponse,
     TokenInfoResponse,

--- a/contracts/token/src/contract.rs
+++ b/contracts/token/src/contract.rs
@@ -1,15 +1,13 @@
+use astroport::asset::addr_validate_to_lower;
+use astroport::token::{InstantiateMsg, MigrateMsg};
 use cosmwasm_std::{
     entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
 };
-
 use cw2::set_contract_version;
 use cw20_base::contract::{create_accounts, execute as cw20_execute, query as cw20_query};
 use cw20_base::msg::{ExecuteMsg, QueryMsg};
 use cw20_base::state::{MinterData, TokenInfo, TOKEN_INFO};
 use cw20_base::ContractError;
-
-use astroport::asset::addr_validate_to_lower;
-use astroport::token::{InstantiateMsg, MigrateMsg};
 
 /// Contract name that is used for migration.
 const CONTRACT_NAME: &str = "astroport-token";

--- a/contracts/tokenomics/maker/examples/maker_schema.rs
+++ b/contracts/tokenomics/maker/examples/maker_schema.rs
@@ -1,9 +1,8 @@
 use std::env::current_dir;
 use std::fs::create_dir_all;
 
-use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
-
 use astroport::maker::{ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
+use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/contracts/tokenomics/maker/src/contract.rs
+++ b/contracts/tokenomics/maker/src/contract.rs
@@ -1,12 +1,6 @@
-use crate::error::ContractError;
-use crate::state::{Config, BRIDGES, CONFIG, OWNERSHIP_PROPOSAL};
 use std::cmp::min;
+use std::collections::{HashMap, HashSet};
 
-use crate::migration;
-use crate::utils::{
-    build_distribute_msg, build_swap_msg, get_pool, try_build_swap_msg, validate_bridge,
-    BRIDGES_EXECUTION_MAX_DEPTH, BRIDGES_INITIAL_DEPTH,
-};
 use astroport::asset::{
     addr_validate_to_lower, native_asset_info, token_asset, token_asset_info, Asset, AssetInfo,
     PairInfo, ULUNA_DENOM, UUSD_DENOM,
@@ -26,7 +20,14 @@ use cosmwasm_std::{
 use cw2::{get_contract_version, set_contract_version};
 use cw20::Cw20ExecuteMsg;
 use paloma_cosmwasm::PalomaQueryWrapper;
-use std::collections::{HashMap, HashSet};
+
+use crate::error::ContractError;
+use crate::migration;
+use crate::state::{Config, BRIDGES, CONFIG, OWNERSHIP_PROPOSAL};
+use crate::utils::{
+    build_distribute_msg, build_swap_msg, get_pool, try_build_swap_msg, validate_bridge,
+    BRIDGES_EXECUTION_MAX_DEPTH, BRIDGES_INITIAL_DEPTH,
+};
 
 /// Contract name that is used for migration.
 const CONTRACT_NAME: &str = "astroport-maker";

--- a/contracts/tokenomics/maker/src/testing.rs
+++ b/contracts/tokenomics/maker/src/testing.rs
@@ -1,13 +1,14 @@
+use std::str::FromStr;
+
+use astroport::maker::{ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
 use cosmwasm_std::testing::{
     mock_env, mock_info, MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR,
 };
 use cosmwasm_std::{from_binary, Addr, Decimal, OwnedDeps, Uint128, Uint64};
+use paloma_cosmwasm::PalomaQueryWrapper;
 
 use crate::contract::{execute, instantiate, query};
 use crate::state::{Config, CONFIG};
-use astroport::maker::{ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
-use paloma_cosmwasm::PalomaQueryWrapper;
-use std::str::FromStr;
 
 /// mock_dependencies is a drop-in replacement for cosmwasm_std::testing::mock_dependencies.
 fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, PalomaQueryWrapper> {

--- a/contracts/tokenomics/maker/src/utils.rs
+++ b/contracts/tokenomics/maker/src/utils.rs
@@ -1,11 +1,12 @@
-use crate::error::ContractError;
-use crate::state::{Config, BRIDGES};
 use astroport::asset::{Asset, AssetInfo, PairInfo};
 use astroport::maker::ExecuteMsg;
 use astroport::pair::Cw20HookMsg;
 use astroport::querier::query_pair_info;
 use cosmwasm_std::{to_binary, Coin, Deps, Env, StdResult, SubMsg, Uint128, WasmMsg};
 use paloma_cosmwasm::PalomaQueryWrapper;
+
+use crate::error::ContractError;
+use crate::state::{Config, BRIDGES};
 
 /// The default bridge depth for a fee token
 pub const BRIDGES_INITIAL_DEPTH: u64 = 0;

--- a/contracts/tokenomics/staking/examples/staking_schema.rs
+++ b/contracts/tokenomics/staking/examples/staking_schema.rs
@@ -1,9 +1,8 @@
 use std::env::current_dir;
 use std::fs::create_dir_all;
 
-use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
-
 use astroport::staking::{ConfigResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/contracts/tokenomics/staking/src/contract.rs
+++ b/contracts/tokenomics/staking/src/contract.rs
@@ -1,21 +1,20 @@
+use astroport::asset::addr_validate_to_lower;
+use astroport::staking::{ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
+use astroport::token::InstantiateMsg as TokenInstantiateMsg;
 use cosmwasm_std::{
     entry_point, from_binary, to_binary, Addr, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
     Reply, ReplyOn, Response, StdError, StdResult, SubMsg, Uint128, WasmMsg,
 };
-
-use crate::error::ContractError;
-use crate::state::{Config, CONFIG};
-use astroport::staking::{ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
 use cw2::set_contract_version;
 use cw20::{
     BalanceResponse, Cw20ExecuteMsg, Cw20QueryMsg, Cw20ReceiveMsg, MinterResponse,
     TokenInfoResponse,
 };
-
-use crate::response::MsgInstantiateContractResponse;
-use astroport::asset::addr_validate_to_lower;
-use astroport::token::InstantiateMsg as TokenInstantiateMsg;
 use protobuf::Message;
+
+use crate::error::ContractError;
+use crate::response::MsgInstantiateContractResponse;
+use crate::state::{Config, CONFIG};
 
 /// Contract name that is used for migration.
 const CONTRACT_NAME: &str = "astroport-staking";

--- a/contracts/tokenomics/vesting/examples/vesting_schema.rs
+++ b/contracts/tokenomics/vesting/examples/vesting_schema.rs
@@ -1,12 +1,11 @@
 use std::env::current_dir;
 use std::fs::create_dir_all;
 
-use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
-
 use astroport::vesting::{
     ConfigResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, VestingAccountResponse,
     VestingAccountsResponse,
 };
+use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/contracts/tokenomics/vesting/src/contract.rs
+++ b/contracts/tokenomics/vesting/src/contract.rs
@@ -1,20 +1,19 @@
-use cosmwasm_std::{
-    attr, entry_point, from_binary, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo,
-    Response, StdError, StdResult, SubMsg, Uint128, WasmMsg,
-};
-
-use crate::state::{read_vesting_infos, Config, CONFIG, OWNERSHIP_PROPOSAL, VESTING_INFO};
-
-use crate::error::ContractError;
 use astroport::asset::addr_validate_to_lower;
 use astroport::common::{claim_ownership, drop_ownership_proposal, propose_new_owner};
 use astroport::vesting::{
     ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, OrderBy, QueryMsg,
     VestingAccount, VestingAccountResponse, VestingAccountsResponse, VestingInfo, VestingSchedule,
 };
+use cosmwasm_std::{
+    attr, entry_point, from_binary, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo,
+    Response, StdError, StdResult, SubMsg, Uint128, WasmMsg,
+};
 use cw2::set_contract_version;
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use paloma_cosmwasm::PalomaQueryWrapper;
+
+use crate::error::ContractError;
+use crate::state::{read_vesting_infos, Config, CONFIG, OWNERSHIP_PROPOSAL, VESTING_INFO};
 
 /// Contract name that is used for migration.
 const CONTRACT_NAME: &str = "astroport-vesting";

--- a/contracts/tokenomics/vesting/src/state.rs
+++ b/contracts/tokenomics/vesting/src/state.rs
@@ -1,10 +1,9 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
 use astroport::common::OwnershipProposal;
 use astroport::vesting::{OrderBy, VestingInfo};
 use cosmwasm_std::{Addr, Deps, StdResult};
 use cw_storage_plus::{Bound, Item, Map};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 /// ## Description
 /// This structure stores the main parameters for the generator vesting contract.
@@ -72,7 +71,8 @@ pub fn read_vesting_infos(
 
 #[test]
 fn read_vesting_infos_as_expected() {
-    use cosmwasm_std::{testing::mock_dependencies, Uint128};
+    use cosmwasm_std::testing::mock_dependencies;
+    use cosmwasm_std::Uint128;
 
     let mut deps = mock_dependencies();
 

--- a/contracts/tokenomics/vesting/src/testing.rs
+++ b/contracts/tokenomics/vesting/src/testing.rs
@@ -1,8 +1,8 @@
-use crate::contract::{instantiate, query};
 use astroport::vesting::{ConfigResponse, InstantiateMsg, QueryMsg};
-
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::{from_binary, Addr};
+
+use crate::contract::{instantiate, query};
 
 #[test]
 fn proper_initialization() {

--- a/contracts/tokenomics/xastro_token/examples/xastro_token_schema.rs
+++ b/contracts/tokenomics/xastro_token/examples/xastro_token_schema.rs
@@ -1,9 +1,8 @@
 use std::env::current_dir;
 use std::fs::create_dir_all;
 
-use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
-
 use astroport::xastro_token::{InstantiateMsg, QueryMsg};
+use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
 use cw20::{
     AllAccountsResponse, AllAllowancesResponse, AllowanceResponse, BalanceResponse, MinterResponse,
     TokenInfoResponse,

--- a/contracts/tokenomics/xastro_token/src/contract.rs
+++ b/contracts/tokenomics/xastro_token/src/contract.rs
@@ -1,15 +1,14 @@
+use astroport::asset::addr_validate_to_lower;
+use astroport::xastro_token::{InstantiateMsg, QueryMsg};
 use cosmwasm_std::{
     attr, entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Order, Response,
     StdError, StdResult, Uint128,
 };
+use cw2::set_contract_version;
 use cw20::{AllAccountsResponse, BalanceResponse, Cw20Coin, Cw20ReceiveMsg};
 use cw20_base::allowances::{
     deduct_allowance, execute_decrease_allowance, execute_increase_allowance, query_allowance,
 };
-
-use crate::state::{capture_total_supply_history, get_total_supply_at, BALANCES};
-use astroport::asset::addr_validate_to_lower;
-use cw2::set_contract_version;
 use cw20_base::contract::{
     execute_update_marketing, execute_upload_logo, query_download_logo, query_marketing_info,
     query_minter, query_token_info,
@@ -20,7 +19,7 @@ use cw20_base::state::{MinterData, TokenInfo, TOKEN_INFO};
 use cw20_base::ContractError;
 use cw_storage_plus::Bound;
 
-use astroport::xastro_token::{InstantiateMsg, QueryMsg};
+use crate::state::{capture_total_supply_history, get_total_supply_at, BALANCES};
 
 /// Contract name that is used for migration.
 const CONTRACT_NAME: &str = "astroport-xastro-token";

--- a/contracts/tokenomics/xastro_token/src/testing.rs
+++ b/contracts/tokenomics/xastro_token/src/testing.rs
@@ -1,5 +1,3 @@
-use crate::contract::{execute, instantiate, query_balance, query_balance_at};
-use crate::state::get_total_supply_at;
 use astroport::xastro_token::InstantiateMsg;
 use cosmwasm_std::testing::{
     mock_dependencies, mock_dependencies_with_balance, mock_env, mock_info, MOCK_CONTRACT_ADDR,
@@ -12,6 +10,9 @@ use cw20::{Cw20Coin, Cw20ReceiveMsg, MinterResponse, TokenInfoResponse};
 use cw20_base::contract::{query_minter, query_token_info};
 use cw20_base::msg::ExecuteMsg;
 use cw20_base::ContractError;
+
+use crate::contract::{execute, instantiate, query_balance, query_balance_at};
+use crate::state::get_total_supply_at;
 
 pub struct MockEnvParams {
     pub block_time: Timestamp,

--- a/contracts/whitelist/examples/whitelist_schema.rs
+++ b/contracts/whitelist/examples/whitelist_schema.rs
@@ -1,9 +1,8 @@
 use std::env::current_dir;
 use std::fs::create_dir_all;
 
-use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
-
 use astroport::whitelist::{AdminListResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
+use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/contracts/whitelist/src/contract.rs
+++ b/contracts/whitelist/src/contract.rs
@@ -1,19 +1,18 @@
-use schemars::JsonSchema;
 use std::fmt;
 
+use astroport::whitelist::{AdminListResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     to_binary, Addr, Api, Binary, CosmosMsg, Deps, DepsMut, Empty, Env, MessageInfo, Response,
     StdResult,
 };
-
 use cw1::CanExecuteResponse;
 use cw2::set_contract_version;
+use schemars::JsonSchema;
 
 use crate::error::ContractError;
 use crate::state::{AdminList, ADMIN_LIST};
-use astroport::whitelist::{AdminListResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
 
 // Version info for contract migration.
 const CONTRACT_NAME: &str = "astroport-cw1-whitelist";
@@ -143,9 +142,10 @@ pub fn query_can_execute(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
     use cosmwasm_std::{coin, coins, BankMsg, StakingMsg, SubMsg, WasmMsg};
+
+    use super::*;
 
     #[test]
     fn instantiate_and_modify_config() {

--- a/contracts/whitelist/src/integration_tests.rs
+++ b/contracts/whitelist/src/integration_tests.rs
@@ -8,7 +8,8 @@ use cw_multi_test::{
     App, AppBuilder, AppResponse, BankKeeper, Contract, ContractWrapper, Executor,
 };
 use derivative::Derivative;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 fn mock_app() -> App {
     AppBuilder::new()

--- a/contracts/whitelist/src/state.rs
+++ b/contracts/whitelist/src/state.rs
@@ -1,8 +1,7 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
 use cosmwasm_std::Addr;
 use cw_storage_plus::Item;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
 pub struct AdminList {

--- a/packages/astroport/src/asset.rs
+++ b/packages/astroport/src/asset.rs
@@ -1,16 +1,17 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 use std::fmt;
 
-use crate::factory::PairType;
-use crate::pair::QueryMsg as PairQueryMsg;
-use crate::querier::{query_balance, query_token_balance, query_token_symbol};
 use cosmwasm_std::{
     to_binary, Addr, Api, BankMsg, Coin, CosmosMsg, Decimal, Deps, MessageInfo, QuerierWrapper,
     StdError, StdResult, Uint128, WasmMsg,
 };
 use cw20::{Cw20ExecuteMsg, Cw20QueryMsg, MinterResponse};
 use paloma_cosmwasm::{PalomaQuerier, PalomaQueryWrapper};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::factory::PairType;
+use crate::pair::QueryMsg as PairQueryMsg;
+use crate::querier::{query_balance, query_token_balance, query_token_symbol};
 
 /// UST token denomination
 pub const UUSD_DENOM: &str = "uusd";

--- a/packages/astroport/src/common.rs
+++ b/packages/astroport/src/common.rs
@@ -1,9 +1,10 @@
-use crate::asset::addr_validate_to_lower;
 use cosmwasm_std::{attr, Addr, DepsMut, Env, MessageInfo, Response, StdError, StdResult};
 use cw_storage_plus::Item;
 use paloma_cosmwasm::PalomaQueryWrapper;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+use crate::asset::addr_validate_to_lower;
 
 const MAX_PROPOSAL_TTL: u64 = 1209600;
 

--- a/packages/astroport/src/factory.rs
+++ b/packages/astroport/src/factory.rs
@@ -1,8 +1,10 @@
-use crate::asset::{AssetInfo, PairInfo};
+use std::fmt::{Display, Formatter, Result};
+
 use cosmwasm_std::{Addr, Binary};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt::{Display, Formatter, Result};
+
+use crate::asset::{AssetInfo, PairInfo};
 
 const MAX_TOTAL_FEE_BPS: u16 = 10_000;
 const MAX_MAKER_FEE_BPS: u16 = 10_000;

--- a/packages/astroport/src/generator.rs
+++ b/packages/astroport/src/generator.rs
@@ -1,11 +1,13 @@
-use crate::asset::{Asset, AssetInfo};
-use crate::factory::PairType;
-use crate::restricted_vector::RestrictedVector;
+use std::fmt::Debug;
+
 use cosmwasm_std::{Addr, Decimal, Uint128, Uint64};
 use cw20::Cw20ReceiveMsg;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
+
+use crate::asset::{Asset, AssetInfo};
+use crate::factory::PairType;
+use crate::restricted_vector::RestrictedVector;
 
 /// This structure describes the parameters used for creating a contract.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/astroport/src/lib.rs
+++ b/packages/astroport/src/lib.rs
@@ -25,8 +25,9 @@ mod mock_querier;
 mod testing;
 
 mod decimal_checked_ops {
-    use cosmwasm_std::{Decimal, Fraction, OverflowError, Uint128, Uint256};
     use std::convert::TryInto;
+
+    use cosmwasm_std::{Decimal, Fraction, OverflowError, Uint128, Uint256};
     pub trait DecimalCheckedOps {
         fn checked_add(self, other: Decimal) -> Result<Decimal, OverflowError>;
         fn checked_mul_u128(self, other: Uint128) -> Result<Uint128, OverflowError>;

--- a/packages/astroport/src/maker.rs
+++ b/packages/astroport/src/maker.rs
@@ -1,8 +1,9 @@
-use crate::asset::{Asset, AssetInfo};
-use crate::factory::UpdateAddr;
 use cosmwasm_std::{Addr, Decimal, Uint128, Uint64};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+use crate::asset::{Asset, AssetInfo};
+use crate::factory::UpdateAddr;
 
 /// This structure stores general parameters for the contract.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/astroport/src/math.rs
+++ b/packages/astroport/src/math.rs
@@ -1,5 +1,6 @@
-use cosmwasm_std::{Decimal, Decimal256, Fraction, Uint128};
 use std::convert::TryInto;
+
+use cosmwasm_std::{Decimal, Decimal256, Fraction, Uint128};
 
 /// Convert a `Decimal256` into a `Decimal`
 #[inline]

--- a/packages/astroport/src/mock_querier.rs
+++ b/packages/astroport/src/mock_querier.rs
@@ -1,17 +1,17 @@
+use std::collections::HashMap;
+
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
     from_binary, from_slice, to_binary, Coin, Decimal, OwnedDeps, Querier, QuerierResult,
     QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
 };
-
-use std::collections::HashMap;
-
-use crate::asset::PairInfo;
-use crate::factory::QueryMsg as FactoryQueryMsg;
 use cw20::{BalanceResponse, Cw20QueryMsg, TokenInfoResponse};
 use paloma_cosmwasm::{
     PalomaQuery, PalomaQueryWrapper, PalomaRoute, TaxCapResponse, TaxRateResponse,
 };
+
+use crate::asset::PairInfo;
+use crate::factory::QueryMsg as FactoryQueryMsg;
 
 /// mock_dependencies is a drop-in replacement for cosmwasm_std::testing::mock_dependencies
 /// This uses the Astroport CustomQuerier.

--- a/packages/astroport/src/oracle.rs
+++ b/packages/astroport/src/oracle.rs
@@ -1,7 +1,8 @@
-use crate::asset::AssetInfo;
 use cosmwasm_std::Uint128;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+use crate::asset::AssetInfo;
 
 /// This structure stores general parameters for the contract.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/astroport/src/pair.rs
+++ b/packages/astroport/src/pair.rs
@@ -1,11 +1,10 @@
+use cosmwasm_std::{from_slice, Addr, Binary, Decimal, Deps, StdResult, Uint128};
+use cw20::Cw20ReceiveMsg;
+use paloma_cosmwasm::PalomaQueryWrapper;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::asset::{Asset, AssetInfo};
-
-use cosmwasm_std::{from_slice, Addr, Binary, Decimal, Deps, StdResult, Uint128};
-use cw20::Cw20ReceiveMsg;
-use paloma_cosmwasm::PalomaQueryWrapper;
 
 /// The default swap slippage
 pub const DEFAULT_SLIPPAGE: &str = "0.005";

--- a/packages/astroport/src/pair_anchor.rs
+++ b/packages/astroport/src/pair_anchor.rs
@@ -1,10 +1,9 @@
+use cosmwasm_std::{Addr, Binary, Decimal, Uint128};
+use cw20::Cw20ReceiveMsg;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::asset::{Asset, AssetInfo};
-
-use cosmwasm_std::{Addr, Binary, Decimal, Uint128};
-use cw20::Cw20ReceiveMsg;
 
 /// The default swap slippage
 pub const DEFAULT_SLIPPAGE: &str = "0.005";

--- a/packages/astroport/src/pair_stable_bluna.rs
+++ b/packages/astroport/src/pair_stable_bluna.rs
@@ -1,10 +1,9 @@
+use cosmwasm_std::{Addr, Binary, Decimal, Uint128};
+use cw20::Cw20ReceiveMsg;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::asset::Asset;
-
-use cosmwasm_std::{Addr, Binary, Decimal, Uint128};
-use cw20::Cw20ReceiveMsg;
 
 /// This structure describes the execute messages available in the contract.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/astroport/src/querier.rs
+++ b/packages/astroport/src/querier.rs
@@ -1,17 +1,16 @@
+use cosmwasm_std::{
+    to_binary, Addr, AllBalanceResponse, BalanceResponse, BankQuery, Coin, Decimal, QuerierWrapper,
+    QueryRequest, StdResult, Uint128, WasmQuery,
+};
+use cw20::{BalanceResponse as Cw20BalanceResponse, Cw20QueryMsg, TokenInfoResponse};
+use paloma_cosmwasm::PalomaQueryWrapper;
+
 use crate::asset::{Asset, AssetInfo, PairInfo};
 use crate::factory::{
     ConfigResponse as FactoryConfigResponse, FeeInfoResponse, PairType, PairsResponse,
     QueryMsg as FactoryQueryMsg,
 };
 use crate::pair::{QueryMsg as PairQueryMsg, ReverseSimulationResponse, SimulationResponse};
-
-use cosmwasm_std::{
-    to_binary, Addr, AllBalanceResponse, BalanceResponse, BankQuery, Coin, Decimal, QuerierWrapper,
-    QueryRequest, StdResult, Uint128, WasmQuery,
-};
-
-use cw20::{BalanceResponse as Cw20BalanceResponse, Cw20QueryMsg, TokenInfoResponse};
-use paloma_cosmwasm::PalomaQueryWrapper;
 
 // It's defined at https://github.com/terra-money/core/blob/d8e277626e74f9d6417dcd598574686882f0274c/types/assets/assets.go#L15
 const NATIVE_TOKEN_PRECISION: u8 = 6;

--- a/packages/astroport/src/restricted_vector.rs
+++ b/packages/astroport/src/restricted_vector.rs
@@ -1,8 +1,10 @@
-use crate::DecimalCheckedOps;
+use std::fmt::Display;
+
 use cosmwasm_std::{Decimal, StdError, StdResult, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
+
+use crate::DecimalCheckedOps;
 
 /// Vec wrapper for internal use.
 /// Some business logic relies on an order of this vector, thus it is forbidden to sort it

--- a/packages/astroport/src/router.rs
+++ b/packages/astroport/src/router.rs
@@ -1,8 +1,7 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
 use cosmwasm_std::{Addr, Decimal, Uint128};
 use cw20::Cw20ReceiveMsg;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::asset::AssetInfo;
 

--- a/packages/astroport/src/testing.rs
+++ b/packages/astroport/src/testing.rs
@@ -1,14 +1,14 @@
+use cosmwasm_std::testing::MOCK_CONTRACT_ADDR;
+use cosmwasm_std::{to_binary, Addr, BankMsg, Coin, CosmosMsg, Decimal, Uint128, WasmMsg};
+use cw20::Cw20ExecuteMsg;
+
 use crate::asset::{format_lp_token_name, Asset, AssetInfo, PairInfo};
+use crate::factory::PairType;
 use crate::mock_querier::mock_dependencies;
 use crate::querier::{
     query_all_balances, query_balance, query_pair_info, query_supply, query_token_balance,
 };
-
-use crate::factory::PairType;
 use crate::DecimalCheckedOps;
-use cosmwasm_std::testing::MOCK_CONTRACT_ADDR;
-use cosmwasm_std::{to_binary, Addr, BankMsg, Coin, CosmosMsg, Decimal, Uint128, WasmMsg};
-use cw20::Cw20ExecuteMsg;
 
 #[test]
 fn token_balance_querier() {

--- a/packages/astroport/src/token.rs
+++ b/packages/astroport/src/token.rs
@@ -1,8 +1,7 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
 use cosmwasm_std::{StdError, StdResult, Uint128};
 use cw20::{Cw20Coin, MinterResponse};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 /// This structure describes the parameters used for creating a token contract.
 /// TokenContract InstantiateMsg

--- a/packages/astroport/src/vesting.rs
+++ b/packages/astroport/src/vesting.rs
@@ -1,8 +1,7 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
 use cosmwasm_std::{Addr, Order, Uint128};
 use cw20::Cw20ReceiveMsg;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 /// This structure describes the parameters used for creating a contract.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/astroport/src/whitelist.rs
+++ b/packages/astroport/src/whitelist.rs
@@ -1,8 +1,8 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use cosmwasm_std::{CosmosMsg, Empty};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 pub struct InstantiateMsg {

--- a/packages/astroport/src/xastro_token.rs
+++ b/packages/astroport/src/xastro_token.rs
@@ -1,8 +1,7 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
 use cosmwasm_std::{StdError, StdResult, Uint128};
 use cw20::{Cw20Coin, MinterResponse};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 /// This structure describes the parameters used for creating a xASTRO token contract.
 #[derive(Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
https://github.com/palomachain/paloma/issues/164

## Background

Use some nightly-only options to `cargo fmt` to imports in palomadex. This formatting scheme will
not last (without including +nightly formatting on CI at least), but it provides some sanity.

## Testing completed

- [x] Existing tests pass.

