### PR TITLE
Include cw20-legacy as a library so it can link.

### DIFF
--- a/wormhole/cw20-wrapped/Cargo.toml
+++ b/wormhole/cw20-wrapped/Cargo.toml
@@ -19,7 +19,7 @@ cosmwasm-storage = "1.0.0"
 cw-storage-plus  = "0.13.4"
 cw2 = "0.13.4"
 cw20 = "0.13.4"
-cw20-legacy = { path = "../cw20-legacy" }
+cw20-legacy = { path = "../cw20-legacy", features = ["library"] }
 schemars = "0.8.10"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = "1.0.31"


### PR DESCRIPTION
https://github.com/palomachain/paloma/issues/177

## Background

Without this feature contracts export `instantiate` and friends.
If it appears as a dependency this means there will be multiple such
symbols.

## Testing completed

- [x] `cargo wasm` builds and links everything

