### PR TITLE
Remove (unused) bigint dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,16 +378,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bdca834647821e0b13d9539a8634eb62d3501b6b6c2cec1722786ee6671b851"
 
 [[package]]
-name = "bigint"
-version = "4.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e8c8a600052b52482eff2cf4d810e462fdff1f656ac1ecb6232132a1ed7def"
-dependencies = [
- "byteorder",
- "crunchy 0.1.6",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,12 +750,6 @@ dependencies = [
  "cfg-if",
  "once_cell",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 
 [[package]]
 name = "crunchy"
@@ -1246,7 +1230,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
 dependencies = [
- "crunchy 0.2.2",
+ "crunchy",
  "fixed-hash",
  "impl-rlp",
  "impl-serde",
@@ -2748,14 +2732,13 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
- "crunchy 0.2.2",
+ "crunchy",
 ]
 
 [[package]]
 name = "token-bridge-paloma"
 version = "0.1.0"
 dependencies = [
- "bigint",
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw20",
@@ -2829,7 +2812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f03af7ccf01dd611cc450a0d10dbc9b745770d096473e2faf0ca6e2d66d1e0"
 dependencies = [
  "byteorder",
- "crunchy 0.2.2",
+ "crunchy",
  "hex",
  "static_assertions",
 ]

--- a/wormhole/token-bridge/Cargo.toml
+++ b/wormhole/token-bridge/Cargo.toml
@@ -29,7 +29,6 @@ sha3 = { version = "0.10.1", default-features = false }
 generic-array = "0.14.5"
 hex = "0.4.3"
 lazy_static = "1.4.0"
-bigint = "4.4.3"
 
 [dev-dependencies]
 serde_json = "1.0.82"


### PR DESCRIPTION
https://github.com/palomachain/paloma-rs/security/dependabot/2

## Background

Bigint has a security alert, but it turns out we aren't even using it.

## Testing completed

- [x] compiles

