### PR TITLE
Extract common foreign chain call interface, use it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,6 +1113,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "xcci",
 ]
 
 [[package]]
@@ -2375,6 +2376,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "xcci",
 ]
 
 [[package]]
@@ -3144,6 +3146,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xcci"
+version = "0.1.0"
+dependencies = [
+ "cosmwasm-std",
+ "schemars",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 [workspace.dependencies]
 anyhow = "1.0.65"
 assert_matches = "1.5.0"
+cosmwasm-std = "1.0.0"
 ethabi = "17.2.0"
 eyre = "0.6.8"
 hex = "0.4.3"
@@ -21,6 +22,7 @@ serde = { version = "1.0.140", default-features = false, features = ["derive"] }
 serde_json = "1.0.85"
 sha3 = "0.10.5"
 thiserror = "1.0.35"
+xcci = { path = "packages/xcci" }
 
 [profile.release]
 opt-level = "z"

--- a/egg/mint/Cargo.toml
+++ b/egg/mint/Cargo.toml
@@ -21,6 +21,7 @@ hex.workspace = true
 rand = "0.8.5"
 schemars.workspace = true
 serde.workspace = true
+xcci.workspace = true
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0"

--- a/egg/mint/src/msg.rs
+++ b/egg/mint/src/msg.rs
@@ -1,6 +1,7 @@
-use cosmwasm_std::{Binary, CustomMsg};
+use cosmwasm_std::Binary;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use xcci::TargetContractInfo;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct MigrateMsg {}
@@ -8,14 +9,6 @@ pub struct MigrateMsg {}
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
     pub target_contract_info: TargetContractInfo,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct TargetContractInfo {
-    pub chain_id: String,
-    pub compass_id: String,
-    pub contract_address: String,
-    pub smart_contract_abi: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -28,12 +21,3 @@ pub enum ExecuteMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub struct CustomResponseMsg {
-    pub target_contract_info: TargetContractInfo,
-    pub payload: Binary,
-}
-
-impl CustomMsg for CustomResponseMsg {}

--- a/egg/mint/src/state.rs
+++ b/egg/mint/src/state.rs
@@ -1,7 +1,7 @@
-use crate::msg::TargetContractInfo;
 use cosmwasm_std::Addr;
 use cw_storage_plus::{Item, Map};
 use std::collections::HashSet;
+use xcci::TargetContractInfo;
 
 pub const ADMIN: Item<Addr> = Item::new("admin");
 

--- a/egg/mint/src/tests.rs
+++ b/egg/mint/src/tests.rs
@@ -2,9 +2,10 @@ use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::{coins, Binary, DepsMut};
 use eyre::Result;
 use std::collections::HashMap;
+use xcci::TargetContractInfo;
 
 use crate::contract::{execute, instantiate, ENTRANCE_FEE};
-use crate::msg::{ExecuteMsg, InstantiateMsg, TargetContractInfo};
+use crate::msg::{ExecuteMsg, InstantiateMsg};
 
 fn add_entrant(deps: DepsMut, n: u16, funds: u128) -> Result<()> {
     execute(

--- a/egg/robin/Cargo.toml
+++ b/egg/robin/Cargo.toml
@@ -18,6 +18,7 @@ eyre.workspace = true
 hex.workspace = true
 schemars.workspace = true
 serde.workspace = true
+xcci.workspace = true
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0"

--- a/egg/robin/src/contract.rs
+++ b/egg/robin/src/contract.rs
@@ -1,8 +1,9 @@
-use crate::msg::{CustomResponseMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use cosmwasm_std::{
     to_binary, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
 };
 use eyre::Result;
+use xcci::ExecutePalomaJob;
 
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
@@ -28,13 +29,13 @@ pub fn execute(
     _env: Env,
     _info: MessageInfo,
     msg: ExecuteMsg,
-) -> Result<Response<CustomResponseMsg>> {
+) -> Result<Response<ExecutePalomaJob>> {
     let ExecuteMsg::Call {
         target_contract_info,
         payload,
     } = msg;
     Ok(
-        Response::new().add_message(CosmosMsg::Custom(CustomResponseMsg {
+        Response::new().add_message(CosmosMsg::Custom(ExecutePalomaJob {
             target_contract_info,
             payload,
         })),

--- a/egg/robin/src/msg.rs
+++ b/egg/robin/src/msg.rs
@@ -1,20 +1,13 @@
-use cosmwasm_std::{Binary, CustomMsg};
+use cosmwasm_std::Binary;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use xcci::TargetContractInfo;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct MigrateMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct TargetContractInfo {
-    pub chain_id: String,
-    pub contract_address: String,
-    pub smart_contract_abi: String,
-    pub compass_id: String,
-}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -24,15 +17,6 @@ pub enum ExecuteMsg {
         payload: Binary,
     },
 }
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub struct CustomResponseMsg {
-    pub target_contract_info: TargetContractInfo,
-    pub payload: Binary,
-}
-
-impl CustomMsg for CustomResponseMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/packages/xcci/Cargo.toml
+++ b/packages/xcci/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "xcci"
+version = "0.1.0"
+edition = "2021"
+description = "Cross chain call interface for Paloma"
+
+[dependencies]
+cosmwasm-std.workspace = true
+schemars.workspace = true
+serde.workspace = true

--- a/packages/xcci/src/lib.rs
+++ b/packages/xcci/src/lib.rs
@@ -1,0 +1,65 @@
+//! This crate implements the foreign chain call interface for Paloma.
+//! Types here may be used to issue an event which initiates a call on
+//! another blockchain. Example:
+//!
+//! ```rust
+//! use cosmwasm_std::{Binary, CosmosMsg, DepsMut, Env, MessageInfo, Response, StdError, entry_point};
+//! use xcci::{ExecutePalomaJob, TargetContractInfo};
+//!
+//! pub enum ExecuteMsg {
+//!     Call {
+//!         target_contract_info: TargetContractInfo,
+//!         payload: Binary,
+//!     }
+//! }
+//!
+//! #[entry_point]
+//! pub fn execute(
+//!     _deps: DepsMut,
+//!     _env: Env,
+//!     _info: MessageInfo,
+//!     msg: ExecuteMsg,
+//! ) -> Result<Response<ExecutePalomaJob>, StdError> {
+//!     let ExecuteMsg::Call {
+//!         target_contract_info,
+//!         payload,
+//!     } = msg;
+//!     Ok(
+//!         Response::new().add_message(CosmosMsg::Custom(ExecutePalomaJob {
+//!             target_contract_info,
+//!             payload,
+//!         })),
+//!     )
+//! }
+//! ```
+
+#![deny(missing_docs)]
+
+use cosmwasm_std::{Binary, CustomMsg};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Metadata necessary to call a specific contract.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct TargetContractInfo {
+    /// The chain id of the target chain, e.g. "eth-main".
+    pub chain_id: String,
+    /// ID of the target chain's compass contract, e.g. "50".
+    pub compass_id: String,
+    /// The address of the contract to run on the target chain,
+    /// e.g. "0xd58Dfd5b39fCe87dD9C434e95428DdB289934179".
+    pub contract_address: String,
+    /// The json encoded ABI of the contract on the target chain.
+    pub smart_contract_abi: String,
+}
+
+/// A struct implementing `CustomMsg` to be passed as a response message.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct ExecutePalomaJob {
+    /// Metadata of the foreign contract we wish to call.
+    pub target_contract_info: TargetContractInfo,
+    /// Payload for the call, encoded appropriately for the target chain and contract.
+    pub payload: Binary,
+}
+
+impl CustomMsg for ExecutePalomaJob {}


### PR DESCRIPTION
## Background

This interface is shared among ~4 contracts and with the go side of paloma, it should be its own crate.

## Testing completed

- [x] existing tests pass

