### PR TITLE
Update egg contracts to work with new paloma job scheduler

### DIFF
--- a/egg/mint/src/contract.rs
+++ b/egg/mint/src/contract.rs
@@ -1,5 +1,5 @@
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
-use crate::state::{ADMIN, ENTRANTS, ETH_WINNERS, PALOMA_WINNERS, TARGET_CONTRACT_INFO};
+use crate::state::{ADMIN, ENTRANTS, ETH_WINNERS, JOB_ID, PALOMA_WINNERS};
 use cosmwasm_std::{
     coin, ensure_eq, to_binary, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Order,
     Response, StdResult,
@@ -28,7 +28,7 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> StdResult<Response> {
     ADMIN.save(deps.storage, &info.sender)?;
-    TARGET_CONTRACT_INFO.save(deps.storage, &msg.target_contract_info)?;
+    JOB_ID.save(deps.storage, &msg.job_id)?;
     PALOMA_WINNERS.save(deps.storage, &HashSet::new())?;
     ETH_WINNERS.save(deps.storage, &HashSet::new())?;
     Ok(Response::new())
@@ -108,12 +108,9 @@ fn pick_winner(
     PALOMA_WINNERS.save(deps.storage, &paloma_winners)?;
     ETH_WINNERS.save(deps.storage, &eth_winners)?;
 
-    let target_contract_info = TARGET_CONTRACT_INFO.load(deps.storage)?;
+    let job_id = JOB_ID.load(deps.storage)?;
     Ok(Response::new()
-        .add_message(CosmosMsg::Custom(ExecutePalomaJob {
-            target_contract_info,
-            payload,
-        }))
+        .add_message(CosmosMsg::Custom(ExecutePalomaJob { job_id, payload }))
         .add_attribute("winning_paloma_address", &paloma_address)
         .add_attribute("winning_eth_address", &eth_address_str))
 }

--- a/egg/mint/src/msg.rs
+++ b/egg/mint/src/msg.rs
@@ -1,14 +1,13 @@
 use cosmwasm_std::Binary;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use xcci::TargetContractInfo;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct MigrateMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
-    pub target_contract_info: TargetContractInfo,
+    pub job_id: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/egg/mint/src/state.rs
+++ b/egg/mint/src/state.rs
@@ -1,11 +1,10 @@
 use cosmwasm_std::Addr;
 use cw_storage_plus::{Item, Map};
 use std::collections::HashSet;
-use xcci::TargetContractInfo;
 
 pub const ADMIN: Item<Addr> = Item::new("admin");
 
-pub const TARGET_CONTRACT_INFO: Item<TargetContractInfo> = Item::new("target_contract_info");
+pub const JOB_ID: Item<String> = Item::new("job_id");
 
 pub const ENTRANTS: Map<Addr, String> = Map::new("entrants");
 pub const PALOMA_WINNERS: Item<HashSet<Addr>> = Item::new("paloma_winners");

--- a/egg/mint/src/tests.rs
+++ b/egg/mint/src/tests.rs
@@ -2,7 +2,6 @@ use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::{coins, Binary, DepsMut};
 use eyre::Result;
 use std::collections::HashMap;
-use xcci::TargetContractInfo;
 
 use crate::contract::{execute, instantiate, ENTRANCE_FEE};
 use crate::msg::{ExecuteMsg, InstantiateMsg};
@@ -25,12 +24,7 @@ fn simple_contest() -> Result<()> {
     let mut deps = mock_dependencies();
 
     let msg = InstantiateMsg {
-        target_contract_info: TargetContractInfo {
-            chain_id: "".to_string(),
-            compass_id: "".to_string(),
-            contract_address: "".to_string(),
-            smart_contract_abi: "".to_string(),
-        },
+        job_id: "job".to_string(),
     };
     let info = mock_info("admin0000", &[]);
     let _ = instantiate(deps.as_mut(), mock_env(), info, msg)?;
@@ -86,12 +80,7 @@ fn simple_errors() -> Result<()> {
     let mut deps = mock_dependencies();
 
     let msg = InstantiateMsg {
-        target_contract_info: TargetContractInfo {
-            chain_id: "".to_string(),
-            compass_id: "".to_string(),
-            contract_address: "".to_string(),
-            smart_contract_abi: "".to_string(),
-        },
+        job_id: "job".to_string(),
     };
     let info = mock_info("admin0000", &[]);
     let _ = instantiate(deps.as_mut(), mock_env(), info, msg)?;

--- a/egg/robin/src/contract.rs
+++ b/egg/robin/src/contract.rs
@@ -30,16 +30,8 @@ pub fn execute(
     _info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response<ExecutePalomaJob>> {
-    let ExecuteMsg::Call {
-        target_contract_info,
-        payload,
-    } = msg;
-    Ok(
-        Response::new().add_message(CosmosMsg::Custom(ExecutePalomaJob {
-            target_contract_info,
-            payload,
-        })),
-    )
+    let ExecuteMsg::Call { job_id, payload } = msg;
+    Ok(Response::new().add_message(CosmosMsg::Custom(ExecutePalomaJob { job_id, payload })))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/egg/robin/src/msg.rs
+++ b/egg/robin/src/msg.rs
@@ -1,7 +1,6 @@
 use cosmwasm_std::Binary;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use xcci::TargetContractInfo;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct MigrateMsg {}
@@ -12,10 +11,7 @@ pub struct InstantiateMsg {}
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    Call {
-        target_contract_info: TargetContractInfo,
-        payload: Binary,
-    },
+    Call { job_id: String, payload: Binary },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/xcci/src/lib.rs
+++ b/packages/xcci/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! pub enum ExecuteMsg {
 //!     Call {
-//!         target_contract_info: TargetContractInfo,
+//!         job_id: String,
 //!         payload: Binary,
 //!     }
 //! }
@@ -21,12 +21,12 @@
 //!     msg: ExecuteMsg,
 //! ) -> Result<Response<ExecutePalomaJob>, StdError> {
 //!     let ExecuteMsg::Call {
-//!         target_contract_info,
+//!         job_id,
 //!         payload,
 //!     } = msg;
 //!     Ok(
 //!         Response::new().add_message(CosmosMsg::Custom(ExecutePalomaJob {
-//!             target_contract_info,
+//!             job_id,
 //!             payload,
 //!         })),
 //!     )
@@ -39,25 +39,11 @@ use cosmwasm_std::{Binary, CustomMsg};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Metadata necessary to call a specific contract.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
-pub struct TargetContractInfo {
-    /// The chain id of the target chain, e.g. "eth-main".
-    pub chain_id: String,
-    /// ID of the target chain's compass contract, e.g. "50".
-    pub compass_id: String,
-    /// The address of the contract to run on the target chain,
-    /// e.g. "0xd58Dfd5b39fCe87dD9C434e95428DdB289934179".
-    pub contract_address: String,
-    /// The json encoded ABI of the contract on the target chain.
-    pub smart_contract_abi: String,
-}
-
 /// A struct implementing `CustomMsg` to be passed as a response message.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct ExecutePalomaJob {
     /// Metadata of the foreign contract we wish to call.
-    pub target_contract_info: TargetContractInfo,
+    pub job_id: String,
     /// Payload for the call, encoded appropriately for the target chain and contract.
     pub payload: Binary,
 }


### PR DESCRIPTION
https://github.com/palomachain/paloma/issues/546

## Background

New job scheduler interface in paloma uses a `job_id` for a job which stores relevant info.

## Testing completed

- [x] Existing tests pass

